### PR TITLE
Implement server callbacks

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from aiogram.fsm.storage.memory import MemoryStorage
 from aiogram.client.default import DefaultBotProperties
 from aiogram.enums import ParseMode
 from config import BOT_TOKEN
+from webserver import start_webserver
 
 from handlers.start import router as start_router
 from handlers.buy_proxy import router as buy_proxy_router
@@ -26,9 +27,14 @@ async def main():
     dp.message.middleware(UserLoaderMiddleware())
     dp.callback_query.middleware(UserLoaderMiddleware())
 
+    runner = await start_webserver(bot)
+
     # Запуск бота
-    print(f"Старт бота")
-    await dp.start_polling(bot)
+    print("Старт бота")
+    try:
+        await dp.start_polling(bot)
+    finally:
+        await runner.cleanup()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -1,0 +1,22 @@
+import pytest
+from unittest.mock import AsyncMock
+from aiohttp.test_utils import TestClient, TestServer
+from aiohttp import web
+
+from webserver import start_webserver, handle_notify
+
+@pytest.mark.asyncio
+async def test_handle_notify_success():
+    bot = AsyncMock()
+    app = web.Application()
+    app['bot'] = bot
+    app.router.add_post('/notify', handle_notify)
+    server = TestServer(app)
+    client = TestClient(server)
+    await client.start_server()
+    resp = await client.post('/notify', json={'telegram_id': 1, 'text': 'hi'})
+    assert resp.status == 200
+    data = await resp.json()
+    assert data['success'] is True
+    bot.send_message.assert_awaited_once_with(chat_id=1, text='hi')
+    await client.close()

--- a/webserver.py
+++ b/webserver.py
@@ -1,0 +1,29 @@
+from aiohttp import web
+
+async def handle_notify(request: web.Request) -> web.Response:
+    """Handle incoming notifications from external server."""
+    bot = request.app['bot']
+    try:
+        data = await request.json()
+    except Exception:
+        return web.json_response({'success': False, 'error': 'Invalid JSON'}, status=400)
+
+    telegram_id = data.get('telegram_id') or data.get('user_id')
+    text = data.get('text') or data.get('message')
+    if not telegram_id or not text:
+        return web.json_response({'success': False, 'error': 'telegram_id and text are required'}, status=400)
+
+    await bot.send_message(chat_id=int(telegram_id), text=text)
+    return web.json_response({'success': True})
+
+async def start_webserver(bot, host: str = '0.0.0.0', port: int = 8080):
+    """Start aiohttp web server for external callbacks."""
+    app = web.Application()
+    app['bot'] = bot
+    app.router.add_post('/notify', handle_notify)
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, host=host, port=port)
+    await site.start()
+    return runner


### PR DESCRIPTION
## Summary
- create aiohttp webserver for POST callbacks
- start webserver alongside bot
- test notification endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68417fcbe200832aa3406a9ee57767e4